### PR TITLE
Remove port from go server

### DIFF
--- a/go.sh
+++ b/go.sh
@@ -14,7 +14,7 @@ read -s -p 'Password: ' PASSWD
 for i in `cat list.txt`
 do
   echo "Requesting deploy for $i"
-  curl http://${GO_SERVER}:8153/go/api/pipelines/$i/schedule \
+  curl http://${GO_SERVER}/go/api/pipelines/$i/schedule \
     -u "$USERID:$PASSWD" \
     -H "Confirm: true" \
     -X POST --data "variables[DOCKER_INSTANCE]=$SLOT"


### PR DESCRIPTION
This allows the user to point at `go.d******.hbc.com`